### PR TITLE
chore: upgrade sqlx to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ redis = { version = "1.0", features = [
 ] }
 serde = "1.0"
 serde_derive = "1.0"
-sqlx = { version = "0.8", features = [
+sqlx = { version = "0.9", features = [
     "runtime-tokio",
     "tls-rustls",
     "chrono",

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -88,7 +88,8 @@ pub mod test {
             sql.push_str(&format!("TRUNCATE TABLE {t}; "));
         }
         sql.push_str("SET FOREIGN_KEY_CHECKS = 1;");
-        sqlx::raw_sql(sql.as_str())
+        // AssertSqlSafe: table names come from the test harness, not external input.
+        sqlx::raw_sql(sqlx::AssertSqlSafe(sql))
             .execute(pool)
             .await
             .expect("truncate all tables");
@@ -142,7 +143,7 @@ pub mod test {
             .map(|t| format!("TRUNCATE TABLE {};", t))
             .collect::<Vec<String>>()
             .join(" ");
-        sqlx::raw_sql(sql.as_str())
+        sqlx::raw_sql(sqlx::AssertSqlSafe(sql))
             .execute(pool)
             .await
             .expect("truncate all tables");
@@ -197,7 +198,7 @@ pub mod test {
             .map(|t| format!("DELETE FROM '{t}'; DELETE FROM SQLITE_SEQUENCE WHERE name = '{t}'; "))
             .collect::<Vec<String>>()
             .join(" ");
-        sqlx::raw_sql(sql.as_str())
+        sqlx::raw_sql(sqlx::AssertSqlSafe(sql))
             .execute(pool)
             .await
             .unwrap_or_else(|_| panic!("delete tables: {}", tables.join(",")));

--- a/src/infra/rdb.rs
+++ b/src/infra/rdb.rs
@@ -45,7 +45,7 @@ pub type RdbArguments = sqlx::mysql::MySqlArguments;
 #[cfg(all(feature = "postgres", not(feature = "mysql")))]
 pub type RdbArguments = sqlx::postgres::PgArguments;
 #[cfg(not(any(feature = "mysql", feature = "postgres")))]
-pub type RdbArguments<'a> = sqlx::sqlite::SqliteArguments<'a>;
+pub type RdbArguments = sqlx::sqlite::SqliteArguments;
 
 pub trait RdbConfigTrait: Clone {
     fn rdb_url(&self) -> String;
@@ -335,7 +335,11 @@ async fn setup_sqlite(p: &RdbPool, init_schema: Option<&String>) -> Result<()> {
         .execute(p)
         .await?;
     if let Some(init_schema) = init_schema {
-        sqlx::raw_sql(init_schema.as_str()).execute(p).await?;
+        // AssertSqlSafe: schema text is statically bundled and contains no user input.
+        // raw_sql needs a `'static` owner, hence the owned copy.
+        sqlx::raw_sql(sqlx::AssertSqlSafe(init_schema.to_string()))
+            .execute(p)
+            .await?;
     }
     Ok(())
 }


### PR DESCRIPTION
- Bump sqlx dependency from 0.8 to 0.9
- Drop lifetime parameter from RdbArguments type alias (SqliteArguments no longer carries a lifetime in 0.9)
- Wrap dynamic raw_sql() inputs in AssertSqlSafe to satisfy the new SqlSafeStr bound (the SQL text contains no user input)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存ライブラリを更新しました。

* **Refactor**
  * データベース層の SQL 処理の安全性を強化しました。内部の SQL 実行時の安全性チェック機構が改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->